### PR TITLE
Make a crude downloading tool with Cocoa

### DIFF
--- a/cget/cget.xcodeproj/project.pbxproj
+++ b/cget/cget.xcodeproj/project.pbxproj
@@ -1,0 +1,245 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		F3E48DBB1AB4F168009D917D /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F3E48DBA1AB4F168009D917D /* main.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		F3E48DB51AB4F168009D917D /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		F3E48DB71AB4F168009D917D /* cget */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = cget; sourceTree = BUILT_PRODUCTS_DIR; };
+		F3E48DBA1AB4F168009D917D /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		F3E48DC11ABB27AB009D917D /* cget-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "cget-Info.plist"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		F3E48DB41AB4F168009D917D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		F3E48DAE1AB4F168009D917D = {
+			isa = PBXGroup;
+			children = (
+				F3E48DB91AB4F168009D917D /* cget */,
+				F3E48DB81AB4F168009D917D /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		F3E48DB81AB4F168009D917D /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F3E48DB71AB4F168009D917D /* cget */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		F3E48DB91AB4F168009D917D /* cget */ = {
+			isa = PBXGroup;
+			children = (
+				F3E48DC11ABB27AB009D917D /* cget-Info.plist */,
+				F3E48DBA1AB4F168009D917D /* main.m */,
+			);
+			path = cget;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		F3E48DB61AB4F168009D917D /* cget */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F3E48DBE1AB4F168009D917D /* Build configuration list for PBXNativeTarget "cget" */;
+			buildPhases = (
+				F3E48DB31AB4F168009D917D /* Sources */,
+				F3E48DB41AB4F168009D917D /* Frameworks */,
+				F3E48DB51AB4F168009D917D /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = cget;
+			productName = cget;
+			productReference = F3E48DB71AB4F168009D917D /* cget */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		F3E48DAF1AB4F168009D917D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0620;
+				ORGANIZATIONNAME = "Daryle Walker";
+				TargetAttributes = {
+					F3E48DB61AB4F168009D917D = {
+						CreatedOnToolsVersion = 6.2;
+					};
+				};
+			};
+			buildConfigurationList = F3E48DB21AB4F168009D917D /* Build configuration list for PBXProject "cget" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = F3E48DAE1AB4F168009D917D;
+			productRefGroup = F3E48DB81AB4F168009D917D /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				F3E48DB61AB4F168009D917D /* cget */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		F3E48DB31AB4F168009D917D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F3E48DBB1AB4F168009D917D /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		F3E48DBC1AB4F168009D917D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		F3E48DBD1AB4F168009D917D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		F3E48DBF1AB4F168009D917D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
+				INFOPLIST_FILE = "cget/cget-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		F3E48DC01AB4F168009D917D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
+				INFOPLIST_FILE = "cget/cget-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		F3E48DB21AB4F168009D917D /* Build configuration list for PBXProject "cget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F3E48DBC1AB4F168009D917D /* Debug */,
+				F3E48DBD1AB4F168009D917D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F3E48DBE1AB4F168009D917D /* Build configuration list for PBXNativeTarget "cget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F3E48DBF1AB4F168009D917D /* Debug */,
+				F3E48DC01AB4F168009D917D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = F3E48DAF1AB4F168009D917D /* Project object */;
+}

--- a/cget/cget.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/cget/cget.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:cget.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/cget/cget/cget-Info.plist
+++ b/cget/cget/cget-Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>io.github.ctmacuser.${PRODUCT_NAME:rfc1034identifier}</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.1</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2015 Daryle Walker. All rights reserved.</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleAllowMixedLocalizations</key>
+	<false/>
+	<key>CFBundleSpokenName</key>
+	<string>see get</string>
+</dict>
+</plist>

--- a/cget/cget/main.m
+++ b/cget/cget/main.m
@@ -1,0 +1,65 @@
+/*
+    @file
+    @brief The app's program driver.
+
+    @copyright © 2015 Daryle Walker.  All rights reserved.
+    @CFBundleIdentifier io.github.ctmacuser.cget
+ 
+    Under the MIT License.
+ 
+    The run-loop structure inspired by the code at <https://gist.github.com/syzdek/3220789>.
+ */
+
+@import Foundation;
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+
+#pragma mark Globals
+
+int   returnCode = EXIT_SUCCESS;
+bool  shouldExit = false;
+
+#pragma mark - Main function
+
+int main(int argc, const char * argv[]) {
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s URL\n", argv[0]);
+        returnCode = EXIT_FAILURE;
+        goto finish;
+    }
+
+    @autoreleasepool {
+        NSRunLoop * const              runLoop = [NSRunLoop currentRunLoop];
+        NSURLSession * const           session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration] delegate:nil delegateQueue:[NSOperationQueue mainQueue]];
+        NSURLSessionDownloadTask * const  task = [session downloadTaskWithURL:[NSURL URLWithString:[NSString stringWithUTF8String:argv[1]]] completionHandler:^(NSURL *location, NSURLResponse *response, NSError *error) {
+            if (error) {
+                fprintf(stderr, "Error, downloading: %s\n", error.localizedFailureReason.UTF8String ?: error.localizedDescription.UTF8String);
+                returnCode = EXIT_FAILURE;
+            } else {
+                NSURL * const  finalLocation = [NSURL fileURLWithPath:response.suggestedFilename isDirectory:NO];
+
+                [[NSFileManager defaultManager] moveItemAtURL:location toURL:finalLocation error:&error];
+                if (error) {
+                    fprintf(stderr, "Error, copying: %s\n", error.localizedFailureReason.UTF8String ?: error.localizedDescription.UTF8String);
+                    returnCode = EXIT_FAILURE;
+                } else {
+                    fprintf(stdout, "%s\n", finalLocation.path.UTF8String);
+                }
+            }
+            shouldExit = true;
+        }];
+
+        if (!task) {
+            returnCode = EXIT_FAILURE;
+            goto finish;
+        }
+        [task resume];
+        while (!shouldExit && [runLoop runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]])
+            ;
+    }
+
+finish:
+    return returnCode;
+}


### PR DESCRIPTION
Create a Foundation tool that downloads a single URL (via command-line
argument) to the working directory with an automatically-defined
file-name. Downloading uses the NSURLSession API with bare-bones
settings and a basic run loop. Error handling is also basic.

Add an Info.plist file that is merged into the flat-file product.